### PR TITLE
Fix minor bugs

### DIFF
--- a/src/lib/Category.js
+++ b/src/lib/Category.js
@@ -100,7 +100,7 @@ export const CategoryFirestore = {
         if(checkCurrentFile) {
           // Each category must have image when they are created successful which means when users update images will remove the old image and replace it with new image
           const deleteOldFile = await FirebaseStorage.deleteFile(folder, categoryForm.image_name_id);
-          if (!deleteOldFile) { // Error happens in replacing old image
+          if (!deleteOldFile.deleted) { // Error happens in replacing old image
             result.status = "error";
             result.message = useAppStore().getMessageMaster.DATA("").CATEGORY_REPLACE_OLD_IMAGE_ERROR;
             return result;

--- a/src/lib/OtherConfig.js
+++ b/src/lib/OtherConfig.js
@@ -68,7 +68,7 @@ export const OtherConfigFirestore = {
                 if (checkCurrentFile) {
                     // Delete the old image and replace it with the new one
                     const deleteOldFile = await FirebaseStorage.deleteFile(folderLocation, sliderForm.image_name_id);
-                    if (!deleteOldFile) { // Error happens in replacing old image
+                    if (!deleteOldFile.deleted) { // Error happens in replacing old image
                         result.status = "error";
                         result.message = useAppStore().getMessageMaster.DATA("").SLIDER_REPLACE_OLD_IMAGE_ERROR;
                         return result;

--- a/src/views/Decks/Decks.vue
+++ b/src/views/Decks/Decks.vue
@@ -36,7 +36,7 @@ const orderBy = ref([
   { name: 'A-z', code: 'title-asc' },
   { name: 'z-A', code: 'title-desc' },
   { name: 'Latest Update', code: 'catalogue_edition-desc' },
-  { name: 'Most Favorited', code: 'fav_count-desc' },
+  { name: 'Most Favorited', code: 'favorite_count-desc' },
 ]);
 const tagInputed = ref('');
 const selectedCategories = ref();
@@ -137,13 +137,13 @@ const nextDecks = async (lastDeck) => {
 };
 
 async function sortData() {
-  // spinner.value = true;
+  spinner.value = true;
 
   let selectedValue = orderedBy.value.code;
   all_decks.value = await getDecks(selectedValue, {tag: tagInputed.value, category: selectedCategories.value});
   loadDataForDecks();
 
-  // spinner.value = false;
+  spinner.value = false;
 };
 
 // function sortAllDeck() {
@@ -153,14 +153,19 @@ async function sortData() {
 // }
 
 async function addFilter() {
-  // spinner.value = true;
+  spinner.value = true;
 
   const tagFilter = tagInputed.value;
   const cateFilter = (selectedCategories.value.length == 1 && selectedCategories.value[0]) || selectedCategories.value.length > 1 ? selectedCategories.value : [];
-  all_decks.value = await getDecks(orderedBy.value.code, {tag: tagFilter, category: cateFilter});
+  if (cateFilter.length === 0 ) { // If users don't choose any category then there will be no decks show on the page.
+    all_decks.value = [];
+    last_deck.value = null;
+  } else {
+    all_decks.value = await getDecks(orderedBy.value.code, {tag: tagFilter, category: cateFilter});
+  }
   loadDataForDecks();
 
-  // spinner.value = false;
+  spinner.value = false;
 };
 
 // function filterOnDecks() {
@@ -256,7 +261,7 @@ watch(() => router.currentRoute.value.params, async () => {
 
       <div class="block-search">
         <!-- <a style="padding-right: 10px;" class="close" href="" @click="clearFilter">Clear</a> -->
-        <Button label="Clear" @click="clearFilter" />
+        <Button severity="warn" label="Clear" @click="clearFilter" />
         <Button label="Save" @click="addFilter" style="margin-left: 5px;" />
       </div>
     </div>


### PR DESCRIPTION
Fix:
- Admin deck images are not saved correctly which leads to images are not deleted in case update and delete. This is because image name id is refreshed everytime update even though there is no change.
- When user chooses nothing in deck filter it should be no decks filter but all decks are still showed up.
Add:
- Add function to count deck favorite when user clicks favorite icon
- Add loading screen when user filters or sorts in deck 
Adjust: 
- Change color of button Clear to orange in Decks filter
- Rename fav_count-desc to favorite_count in orderBy in deck