### PR TITLE
Cate css fix

### DIFF
--- a/src/components/CateCard.vue
+++ b/src/components/CateCard.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="cate-card-box" :key="data.id" @click="deckRouting(data.id)">
+    <div class="cate-card-box" :key="data.id" @click="deckRouting(data.id)" id="cate-box">
         <div class="cate-card-image">
 
             <img draggable="false" width="110" height="110" fill="none" :src="data.image" />

--- a/src/components/CateCard.vue
+++ b/src/components/CateCard.vue
@@ -69,12 +69,13 @@ const deckRouting = (id) => {
 }
 
 .cate-card-name {
-    height: 50%;
+    height: auto;
     width: 70%;
+    overflow: hidden;
     word-wrap: break-word;
     overflow-wrap: break-word;
     text-align: center;
-    white-space: normal !important;
+    /* white-space: normal !important; */
     font-size: 20px;
     font-weight: 600;
 }

--- a/src/components/CateHorizon.vue
+++ b/src/components/CateHorizon.vue
@@ -107,8 +107,6 @@ const categoryRouting = (id) => {
 }
 /* FUNCTION END */
 
-// computed({})
-
 onMounted(async () => {
   cards.value = await getCategories();
   await nextTick();
@@ -181,6 +179,7 @@ onMounted(async () => {
 }
 
 .card {
+  /* width: 124px; */
   height: 124px;
   display: inline-flex;
   box-shadow: 0px 4px 4px 0px #00000040;

--- a/src/components/CateHorizon.vue
+++ b/src/components/CateHorizon.vue
@@ -112,6 +112,19 @@ const categoryRouting = (id) => {
 onMounted(async () => {
   cards.value = await getCategories();
   await nextTick();
+  
+  const cardItems = document.getElementsByClassName("card");
+  let largestWidth = 0;
+  for (let i = 0; i < cardItems.length; i++) {
+    // const computedWidth = cardItems[i].offsetWidth; 
+    // cardItems[i].style.width = `${Math.max(computedWidth, 128)}px`;
+    if (cardItems[i].offsetWidth > largestWidth) {
+      largestWidth = cardItems[i].offsetWidth;
+    }
+  }
+  for (let i = 0; i < cardItems.length; i++) {
+    cardItems[i].style.width = `${largestWidth}px`;
+  }
   setStep();
   resetTranslate();
 });
@@ -168,7 +181,6 @@ onMounted(async () => {
 }
 
 .card {
-  width: 124px;
   height: 124px;
   display: inline-flex;
   box-shadow: 0px 4px 4px 0px #00000040;

--- a/src/lib/OtherConfig.js
+++ b/src/lib/OtherConfig.js
@@ -193,5 +193,25 @@ export const OtherConfigFirestore = {
             console.log(error);
         }
         return result;
-    }
+    },
+    deleteEmailContacts: async (id, email) => {
+        const result = {
+            status: "success",
+            message: "",
+            data: {},
+        };
+
+        try {
+            await deleteDoc(
+                doc(getFirestore(), useAppStore().getEmailContactCollection, id)
+            ).then((response) => {
+                result.message = useAppStore().getMessageMaster.DATA(email).EMAIL_CONTACT_DELETED;
+            });
+        } catch (error) {
+            result.status = "error";
+            result.message = error.message;
+        }
+
+        return result;
+    },
 };

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -49,7 +49,8 @@ export const useAppStore = defineStore("storeId", {
           EMAIL_CONTACT_CREATED: `Created contact email ${data} successfully.`,
           EMAIL_CONTACT_EXISTED: `Contact email ${data} has already existed.`,
           EMAIL_CONTACT_UPDATED: `Updated contact email ${data} successfully.`,
-          EMAIL_CONTACT_NOT_EXISTED: `Contact email ${data} is not existed`,
+          EMAIL_CONTACT_DELETED: `Deleted contact email ${data} successfully.`,
+          EMAIL_CONTACT_NOT_EXISTED: `Contact email ${data} is not existed.`,
         }
       },
       ADMIN_SITE: {

--- a/src/views/AdminOtherConfig/HomeSliderConfig.vue
+++ b/src/views/AdminOtherConfig/HomeSliderConfig.vue
@@ -8,7 +8,6 @@ import { getAuth } from 'firebase/auth';
 import { Timestamp } from 'firebase/firestore';
 import Button from 'primevue/button';
 import Column from 'primevue/column';
-import ConfirmDialog from 'primevue/confirmdialog';
 import DataTable from 'primevue/datatable';
 import Dialog from 'primevue/dialog';
 import FileUpload from 'primevue/fileupload';
@@ -16,8 +15,6 @@ import IconField from 'primevue/iconfield';
 import InputIcon from 'primevue/inputicon';
 import InputNumber from 'primevue/inputnumber';
 import InputText from 'primevue/inputtext';
-import Select from 'primevue/select';
-import Toast from 'primevue/toast';
 import { useConfirm } from 'primevue/useconfirm';
 import { useToast } from 'primevue/usetoast';
 import { computed, onMounted, reactive, ref, watch } from 'vue';
@@ -289,8 +286,6 @@ const emits = defineEmits(['setLoading']);
 </script>
 
 <template>
-    <Toast />
-    <ConfirmDialog />
     <Dialog v-model:visible="visible" modal :header='formFields.id ? formFields.id : "New Slider"'
         :style="{ width: '50vw' }" :breakpoints="{ '1199px': '75vw', '575px': '90vw' }">
         <div class="form-container">

--- a/src/views/AdminOtherConfig/OtherConfig.vue
+++ b/src/views/AdminOtherConfig/OtherConfig.vue
@@ -1,14 +1,16 @@
 <script setup>
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
-import Tab from 'primevue/tab';
-import TabList from 'primevue/tablist';
-import TabPanel from 'primevue/tabpanel';
-import TabPanels from 'primevue/tabpanels';
-import Tabs from 'primevue/tabs';
+// import Tab from 'primevue/tab';
+// import TabList from 'primevue/tablist';
+// import TabPanel from 'primevue/tabpanel';
+// import TabPanels from 'primevue/tabpanels';
+// import Tabs from 'primevue/tabs';
 import { defineAsyncComponent, markRaw, ref } from 'vue';
 import HomeSliderConfig from './HomeSliderConfig.vue';
 import EmailContactConfig from './EmailContactConfig.vue';
 import Divider from 'primevue/divider';
+import Toast from 'primevue/toast';
+import ConfirmDialog from 'primevue/confirmdialog';
 
 
 /* REF DEFINITION START */
@@ -43,6 +45,8 @@ const setLoading = (value) => {
 
 <template>
     <LoadingSpinner v-if="spinner"/>
+    <Toast />
+    <ConfirmDialog />
     <div class="config-container">
         <!-- <Tabs value="0">
             <TabList>


### PR DESCRIPTION
Adjust:
- Category cards in file CateHorizon.vue to have flexible boxes based on it's string content
- Adjust the box width to auto and height to auto in file CateCard.vue used by Category.vue => if a string content is too long it will break CSS of that box so we need to adjust here as well not only in Home.view
Add:
- Delete function in Email Contact Config
- Remove Toast and Confirm in Home Slider Config => moved these two PrimeVue libraries to main file OtherConfig.vue because it only needs to call one time if in child components there are libraries like these it will be triggered twice or third.