### PR TITLE
Handle feed back for File upload and Deck UI

### DIFF
--- a/src/views/AdminCategory/AdminCategory.vue
+++ b/src/views/AdminCategory/AdminCategory.vue
@@ -287,7 +287,7 @@ watch(visible, () => {
                         <label class="form-label" for="image">Image <span class="required-icon">*</span></label>
                         <img draggable="false" v-if="imagePreview" :src="imagePreview" alt="Image" width="64" />
                         <FileUpload @select="onFileSelected" ref="image" mode="basic" name="image[]"
-                            :maxFileSize="1000000" accept="image/*" />
+                            :maxFileSize="5242880" accept="image/*" />
                         <small class="error-messages" v-if="imageRule$.imagePreview.$errors.length > 0">{{
                             imageRule$.imagePreview.$errors[0].$message }}</small>
                     </div>

--- a/src/views/AdminDeck/AdminDeck.vue
+++ b/src/views/AdminDeck/AdminDeck.vue
@@ -573,7 +573,7 @@ watch(visible, () => {
                         <img draggable="false" v-if="deckHighlightPreview" :src="deckHighlightPreview" alt="Image"
                             width="150" height="150" />
                         <FileUpload @select="onImageSelected" ref="deck_highlight" mode="basic" name="deck_highlight[]"
-                            :maxFileSize="1000000" accept="image/*" />
+                            :maxFileSize="5242880" accept="image/*" />
                         <small class="error-messages" v-if="imageHighlight$.$errors.length > 0">{{
                             imageHighlight$.$errors[0].$message }}</small>
                     </div>
@@ -607,7 +607,7 @@ watch(visible, () => {
                         <label class="form-label" for="deck_images">Deck Images (1200x800px) <span
                                 class="required-icon">*</span></label>
                         <Toast />
-                        <FileUpload ref="multiple_file_upload" :multiple="true" accept="image/*" :maxFileSize="1000000"
+                        <FileUpload ref="multiple_file_upload" :multiple="true" accept="image/*" :maxFileSize="5242880"
                             @select="onSelectedFiles" @clear="onClearFiles">
                             <template #header="{ chooseCallback, clearCallback, files }">
                                 <div class="flex flex-wrap justify-between items-center flex-1 gap-4">
@@ -657,7 +657,7 @@ watch(visible, () => {
                     <div class="flex flex-col">
                         <label class="form-label" for="pdf">PDF Link <span class="required-icon">*</span></label>
                         <InputText readonly v-model="pdfFile" />
-                        <FileUpload @select="onFileSelected" ref="pdf" mode="basic" name="pdf[]" :maxFileSize="1000000"
+                        <FileUpload @select="onFileSelected" ref="pdf" mode="basic" name="pdf[]" :maxFileSize="26214400"
                             accept="application/pdf" />
                         <small class="error-messages" v-if="pdfFile$.$errors.length > 0">{{
                             pdfFile$.$errors[0].$message }}</small>

--- a/src/views/AdminOtherConfig/HomeSliderConfig.vue
+++ b/src/views/AdminOtherConfig/HomeSliderConfig.vue
@@ -299,7 +299,7 @@ const emits = defineEmits(['setLoading']);
                     <label class="form-label" for="banner_title">Image<span class="required-icon">*</span></label>
                     <img draggable="false" v-if="imagePreviewer" :src="imagePreviewer" alt="Image" width="64"
                         height="64" style="object-fit: contain;" />
-                    <FileUpload @select="onFileSelected" ref="image" mode="basic" name="image[]" :maxFileSize="1000000"
+                    <FileUpload @select="onFileSelected" ref="image" mode="basic" name="image[]" :maxFileSize="5242880"
                         accept="image/*" />
                     <small class="error-messages" v-if="imageV$.imagePreviewer.$errors.length > 0">{{
                         imageV$.imagePreviewer.$errors[0].$message }}</small>

--- a/src/views/Decks/Decks.vue
+++ b/src/views/Decks/Decks.vue
@@ -103,17 +103,14 @@ const onLoadEvents = async () => {
   cateIDParm.value = useAppStore().getDeckCategory;
   orderedBy.value = { name: 'Latest Update', code: 'catalogue_edition-desc' };
 
-  // Old logic related to cateIDParam
-  // if (cateIDParm.value) {
-  //   selectedCategories.value = [cateIDParm.value];
-  // } else {
-  //   const categoryOptions = _.map(categories.value, 'key');
-  //   selectedCategories.value = categoryOptions;
-  //   selectedCategoriesUsedForLogicHandler.value = categoryOptions;
-  // }
-  const categoryOptions = _.map(categories.value, 'key');
-  selectedCategories.value = categoryOptions;
-  selectedCategoriesUsedForLogicHandler.value = categoryOptions;
+  if (cateIDParm.value) {
+    selectedCategoriesUsedForLogicHandler.value = [cateIDParm.value];
+    selectedCategories.value = [cateIDParm.value];
+  } else {
+    const categoryOptions = _.map(categories.value, 'key');
+    selectedCategories.value = categoryOptions;
+    selectedCategoriesUsedForLogicHandler.value = categoryOptions;
+  }
   tagInputed.value = '';
 
   all_decks.value = await getDecks(orderedBy.value.code, { tag: tagInputed.value, category: selectedCategoriesUsedForLogicHandler.value });


### PR DESCRIPTION
- Adjust maximum a image can be uploaded to 5MB
- Adjust maximum a pdf file can be uploaded to 25MB
- Fix how categories function click handler. Before it was fixed, it will redirect to Deck UI but all decks are filter all categories not selected categories.