### PR TITLE
16122024_DH - Resolve bugs related to this moment convert date into M…

### DIFF
--- a/src/components/DeckCard.vue
+++ b/src/components/DeckCard.vue
@@ -2,7 +2,7 @@
     <div class="col">
         <div class="my-card-deck" :style="backgroundImage(data.deck_highlight)" :key="data.id">
             <div class="deck-date">
-                <Chip :label="moment(new Date(data.catalogue_edition)).format('MMM YYYY')" />
+                <Chip :label="data.catalogue_edition" />
             </div>
             <div class="deck-info">
                 <div class="deck-info-desc">

--- a/src/lib/CommonLib.js
+++ b/src/lib/CommonLib.js
@@ -1,0 +1,46 @@
+const monthShortNameArray = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec"
+];
+const monthFullNameArray = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December"
+];
+
+export const CommonLib = {
+    // Date handlers
+    /**
+     * date: Transfer the date you want to get only month and year for the first param ||
+     * monthPosition: the position of month in the string date ||
+     * yearPosition: the position of the year in the string date ||
+     * separator: which is - or / used in a date string, Exp: 01/01/0001 => / is the separator of this string ||
+     * keepSeparator: if you want to keep separator in the result string of this function just transfer true to this function. Results can be like this: Jan/2024 and with false value it will be like this: Jan 2024
+     */
+    getOnlyMonthAndYearForShortDate(date, monthPosition, yearPosition, separator, keepSeparator = false) {
+        const splittedDate = date.split(separator);
+        if (keepSeparator) {
+            return `${monthShortNameArray[parseInt(splittedDate[monthPosition]) - 1]}${separator}${splittedDate[yearPosition]}`;
+        }
+        return `${monthShortNameArray[parseInt(splittedDate[monthPosition]) - 1]} ${splittedDate[yearPosition]}`;
+    },
+};

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -9,6 +9,10 @@ export const useAppStore = defineStore("storeId", {
       home_slider: "home_slider",
       contact_emails: "contact_emails"
     },
+    dateFormats: {
+      ADMIN_DECK: "YYYY/MM/DD",
+      DECK: "YYYY/MM/DD"
+    },
     MessageMaster: {
       AUTH: {
         NOT_LOGGED_IN: "User is not logged in to the system",
@@ -92,6 +96,11 @@ export const useAppStore = defineStore("storeId", {
     },
     getDeckCategory: (state) => {
       return state.DATA.DECK_CATEGORY;
+    },
+
+    // DATE FORMATS
+    getDateFormats: (state) => {
+      return state.dateFormats;
     }
   },
   actions: {

--- a/src/views/AdminDeck/AdminDeck.vue
+++ b/src/views/AdminDeck/AdminDeck.vue
@@ -28,6 +28,8 @@ import { useConfirm } from "primevue/useconfirm";
 import DatePicker from "primevue/datepicker";
 import moment from "moment";
 import { ExportData } from "@/lib/Export";
+import { CommonLib } from "@/lib/CommonLib";
+import { useAppStore } from "@/stores";
 
 const formFields = reactive({
     id: '',
@@ -44,6 +46,9 @@ const formFields = reactive({
     tag: [],
     catalogue_edition: '',
 });
+
+/* STATIC VALUES */
+const dateFormat = useAppStore().dateFormats.ADMIN_DECK;
 
 /* COMPUTED VALUES */
 const rules = computed(() => {
@@ -512,7 +517,13 @@ const onFileSelected = (event) => {
 };
 
 const formatDate = (value) => {
-    return value ? moment(value).format('MMM/YYYY') : '';
+    const momentDate = moment(new Date(value)); // When load this timestamp data to table it already converted to a date string.
+    if (momentDate.isValid()) {
+        const formattedDate = momentDate.format(dateFormat);
+        return CommonLib.getOnlyMonthAndYearForShortDate(formattedDate, 1, 0, "/", true);
+    }
+    
+    return "";
 };
 
 const exportMyList = (event) => {

--- a/src/views/Decks/Decks.vue
+++ b/src/views/Decks/Decks.vue
@@ -22,6 +22,8 @@ import router from '@/router';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import _ from 'lodash';
 import { useAppStore } from '@/stores';
+import moment from 'moment';
+import { CommonLib } from '@/lib/CommonLib';
 
 /* REF DEFINITION START */
 const op = ref();
@@ -49,6 +51,7 @@ const deckSectionPageHeader = "Lastest Decks";
 const sectionIcon = Presentation;
 const sectionText = "Decks";
 const limit = 14;
+const dateFormat = useAppStore().getDateFormats.DECK;
 
 /* FUNCTION DEFINTION START */
 const toggle = (event) => {
@@ -74,6 +77,12 @@ const getDecks = async (orderBy, filter, lastDeck) => {
   for (const deck of decksSnapshot) {
     const data = deck.data();
     // const categoryName = await CategoryFirestore.getCategoryName(data.category_id);
+    let convertedCatalogueEdition = "";
+    const momentDate = moment(new Date(data.catalogue_edition.toDate())); // Have to use toDate because this field is timestamp in Firebase if we use new Date(data.catalogue_edition) for this it will not work as an normal date.
+    if (momentDate.isValid()) {
+      const formattedDate = momentDate.format(dateFormat);
+      convertedCatalogueEdition = CommonLib.getOnlyMonthAndYearForShortDate(formattedDate, 1, 0, "/", false);
+    }
     const object = {
       id: deck.id,
       title: data.title,
@@ -85,7 +94,7 @@ const getDecks = async (orderBy, filter, lastDeck) => {
       // pdf: data.pdf,
       // fav_count: await FavoriteFirestore.countFavoriteDecks(deck.id),
       tag: data.tag,
-      catalogue_edition: data.catalogue_edition ? data.catalogue_edition.toDate().toLocaleString() : '',
+      catalogue_edition: convertedCatalogueEdition,
       // created: data.created ? data.created.toDate().toLocaleString() : '',
       // created_by: data.created_by || '',
       // updated: data.updated ? data.updated.toDate().toLocaleString() : '',


### PR DESCRIPTION
Handle feedback related to this Incident, users claim that some browsers are not capable showing date string with format: MMM YYYY.
- Convert timestamp to best practice date format YYYY/MM/DD
- Manually split YYYY and MM from the date string
- Convert number MM to month short names with array
- Add a check for date value if it is valid then do the process convert if it doesn't return empty string
- Adjust these changes in Decks.vue and AdminDeck.vue