### PR TITLE
17122024_DH_V1 - Handle feedback related to Deck's catalogue edition data date format.

### DIFF
--- a/src/components/DeckCard.vue
+++ b/src/components/DeckCard.vue
@@ -33,12 +33,11 @@ import Chip from 'primevue/chip';
 import Button from 'primevue/button';
 import Tag from 'primevue/tag';
 import router from '@/router';
-import { ref, defineEmits, onMounted } from 'vue';
+import { ref, onMounted } from 'vue';
 
 import FavoriteBlackIcon from '@/assets/img/icon/favorite_black.png';
 import FavoriteRedIcon from '@/assets/img/icon/favorite_red.png';
 import { FavoriteFirestore } from '@/lib/Favorite';
-import moment from 'moment';
 
 const props = defineProps({
     data: {

--- a/src/lib/CommonLib.js
+++ b/src/lib/CommonLib.js
@@ -1,46 +1,89 @@
-const monthShortNameArray = [
-    "Jan",
-    "Feb",
-    "Mar",
-    "Apr",
-    "May",
-    "Jun",
-    "Jul",
-    "Aug",
-    "Sep",
-    "Oct",
-    "Nov",
-    "Dec"
-];
-const monthFullNameArray = [
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December"
-];
+const monthArrayObject = [
+    {
+        month: 0,
+        short_name: "Jan",
+        full_name: "January"
+    },
+    {
+        month: 1,
+        short_name: "Feb",
+        full_name: "February"
+    },
+    {
+        month: 2,
+        short_name: "Mar",
+        full_name: "March"
+    },
+    {
+        month: 3,
+        short_name: "Apr",
+        full_name: "April"
+    },
+    {
+        month: 4,
+        short_name: "May",
+        full_name: "May"
+    },
+    {
+        month: 5,
+        short_name: "Jun",
+        full_name: "June"
+    },
+    {
+        month: 6,
+        short_name: "Jul",
+        full_name: "July"
+    },
+    {
+        month: 7,
+        short_name: "Aug",
+        full_name: "August"
+    },
+    {
+        month: 8,
+        short_name: "Sep",
+        full_name: "September"
+    },
+    {
+        month: 9,
+        short_name: "Oct",
+        full_name: "October"
+    },
+    {
+        month: 10,
+        short_name: "Nov",
+        full_name: "November"
+    },
+    {
+        month: 11,
+        short_name: "Dec",
+        full_name: "December"
+    },
+]
 
 export const CommonLib = {
     // Date handlers
     /**
-     * date: Transfer the date you want to get only month and year for the first param ||
-     * monthPosition: the position of month in the string date ||
-     * yearPosition: the position of the year in the string date ||
-     * separator: which is - or / used in a date string, Exp: 01/01/0001 => / is the separator of this string ||
-     * keepSeparator: if you want to keep separator in the result string of this function just transfer true to this function. Results can be like this: Jan/2024 and with false value it will be like this: Jan 2024
+     * Only handle string with this kind of format: 202401 => YYYYMM
      */
-    getOnlyMonthAndYearForShortDate(date, monthPosition, yearPosition, separator, keepSeparator = false) {
-        const splittedDate = date.split(separator);
-        if (keepSeparator) {
-            return `${monthShortNameArray[parseInt(splittedDate[monthPosition]) - 1]}${separator}${splittedDate[yearPosition]}`;
+    getOnlyMonthAndYearForDeckCatalogueEdition(dateString) {
+        const dateStringLength = dateString.length;
+        const month =  dateString[dateStringLength - 2] + "" + dateString[dateStringLength - 1]; // Get last to digit of the string. Example: 202401 => return 01
+        let year = "";
+        for (let i = 0; i < dateStringLength - 2; i++) {
+            year += dateString[i];
         }
-        return `${monthShortNameArray[parseInt(splittedDate[monthPosition]) - 1]} ${splittedDate[yearPosition]}`;
+        const monthDataObj = monthArrayObject[parseInt(month) - 1];
+        if (monthDataObj) {
+            const dateValue = new Date();
+            dateValue.setMonth(monthDataObj.month);
+            dateValue.setFullYear(year);
+            dateValue.setDate(15);
+            return {
+                date_string: `${monthDataObj.short_name}/${year}`,
+                date_value: dateValue
+            }; 
+        }
+        return "";
     },
 };

--- a/src/lib/SearchPage.js
+++ b/src/lib/SearchPage.js
@@ -1,7 +1,6 @@
 import { useAppStore } from "@/stores";
 import { collection, getDocs, getFirestore, query, where } from "firebase/firestore";
 import _ from 'lodash';
-import moment from "moment";
 import { CommonLib } from "./CommonLib";
 
 export const SearchPageFirestore = {
@@ -14,7 +13,6 @@ export const SearchPageFirestore = {
             let myQuery = query(db);
             let snapshot = await getDocs(myQuery);
             let result = snapshot.docs;
-            const dateFormat = useAppStore().getDateFormats.DECK;
             if (!isTag) {
                 result = _.filter(result, (item) => {
                     const dataItem = item.data();
@@ -33,13 +31,8 @@ export const SearchPageFirestore = {
             }
             result = _.map(result, (item) => {
                 const data = item.data();
-                let convertedCatalogueEdition = "";
-                const momentDate = moment(new Date(data.catalogue_edition.toDate()));
-                if (momentDate.isValid()) {
-                    const formattedDate = momentDate.format(dateFormat);
-                    convertedCatalogueEdition = CommonLib.getOnlyMonthAndYearForShortDate(formattedDate, 1, 0, "/", false);
-                }
-                data.catalogue_edition = convertedCatalogueEdition;
+                const convertedDate = CommonLib.getOnlyMonthAndYearForDeckCatalogueEdition(data.catalogue_edition.toString());
+                data.catalogue_edition = convertedDate ? convertedDate.date_string.replace("/", " ") : "";
                 return {
                     id: item.id,
                     ...data,

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -9,10 +9,6 @@ export const useAppStore = defineStore("storeId", {
       home_slider: "home_slider",
       contact_emails: "contact_emails"
     },
-    dateFormats: {
-      ADMIN_DECK: "YYYY/MM/DD",
-      DECK: "YYYY/MM/DD"
-    },
     MessageMaster: {
       AUTH: {
         NOT_LOGGED_IN: "User is not logged in to the system",
@@ -97,11 +93,6 @@ export const useAppStore = defineStore("storeId", {
     getDeckCategory: (state) => {
       return state.DATA.DECK_CATEGORY;
     },
-
-    // DATE FORMATS
-    getDateFormats: (state) => {
-      return state.dateFormats;
-    }
   },
   actions: {
     setmail(email) {

--- a/src/views/Decks/Decks.vue
+++ b/src/views/Decks/Decks.vue
@@ -22,7 +22,6 @@ import router from '@/router';
 import LoadingSpinner from '@/components/LoadingSpinner.vue';
 import _ from 'lodash';
 import { useAppStore } from '@/stores';
-import moment from 'moment';
 import { CommonLib } from '@/lib/CommonLib';
 
 /* REF DEFINITION START */
@@ -51,7 +50,6 @@ const deckSectionPageHeader = "Lastest Decks";
 const sectionIcon = Presentation;
 const sectionText = "Decks";
 const limit = 14;
-const dateFormat = useAppStore().getDateFormats.DECK;
 
 /* FUNCTION DEFINTION START */
 const toggle = (event) => {
@@ -77,12 +75,7 @@ const getDecks = async (orderBy, filter, lastDeck) => {
   for (const deck of decksSnapshot) {
     const data = deck.data();
     // const categoryName = await CategoryFirestore.getCategoryName(data.category_id);
-    let convertedCatalogueEdition = "";
-    const momentDate = moment(new Date(data.catalogue_edition.toDate())); // Have to use toDate because this field is timestamp in Firebase if we use new Date(data.catalogue_edition) for this it will not work as an normal date.
-    if (momentDate.isValid()) {
-      const formattedDate = momentDate.format(dateFormat);
-      convertedCatalogueEdition = CommonLib.getOnlyMonthAndYearForShortDate(formattedDate, 1, 0, "/", false);
-    }
+    const convertedDate = CommonLib.getOnlyMonthAndYearForDeckCatalogueEdition(data.catalogue_edition.toString());
     const object = {
       id: deck.id,
       title: data.title,
@@ -94,7 +87,7 @@ const getDecks = async (orderBy, filter, lastDeck) => {
       // pdf: data.pdf,
       // fav_count: await FavoriteFirestore.countFavoriteDecks(deck.id),
       tag: data.tag,
-      catalogue_edition: convertedCatalogueEdition,
+      catalogue_edition: convertedDate ? convertedDate.date_string.replace("/", " ") : "",
       // created: data.created ? data.created.toDate().toLocaleString() : '',
       // created_by: data.created_by || '',
       // updated: data.updated ? data.updated.toDate().toLocaleString() : '',

--- a/src/views/Home/HomeView.vue
+++ b/src/views/Home/HomeView.vue
@@ -10,8 +10,6 @@ import SupplyChainIcon from '@/assets/img/icon/supply-chain.png';
 import MegaphoneIcon from '@/assets/img/icon/megaphone.png';
 import { DeckFirestore } from '@/lib/Deck';
 import { getAuth } from 'firebase/auth';
-import moment from 'moment';
-import { useAppStore } from '@/stores';
 import { CommonLib } from '@/lib/CommonLib';
 
 const top_decks = ref([]);
@@ -29,7 +27,6 @@ const categoryPageHeader = "Discover Decks by Category";
 const deckSectionIcon = MegaphoneIcon;
 const deckSectionText = "Deck";
 const deckPageHeader = "Latest Decks";
-const dateFormat = useAppStore().getDateFormats.DECK;
 
 /* FUNCTIONS DEFINITION START */
 const getDecks = async () => {
@@ -37,12 +34,7 @@ const getDecks = async () => {
   const decksSnapshot = await DeckFirestore.getTopDecks();
   for (const deck of decksSnapshot) {
     const data = deck.data();
-    let convertedCatalogueEdition = "";
-    const momentDate = moment(new Date(data.catalogue_edition.toDate())); // Have to use toDate because this field is timestamp in Firebase if we use new Date(data.catalogue_edition) for this it will not work as an normal date.
-    if (momentDate.isValid()) {
-      const formattedDate = momentDate.format(dateFormat);
-      convertedCatalogueEdition = CommonLib.getOnlyMonthAndYearForShortDate(formattedDate, 1, 0, "/", false);
-    }
+    const convertedDate = CommonLib.getOnlyMonthAndYearForDeckCatalogueEdition(data.catalogue_edition.toString());
     // const categoryName = await CategoryFirestore.getCategoryName(data.category_id);
     const object = {
       id: deck.id,
@@ -54,7 +46,7 @@ const getDecks = async () => {
       // deck_images: data.deck_images,
       // pdf: data.pdf,
       tag: data.tag,
-      catalogue_edition: convertedCatalogueEdition,
+      catalogue_edition: convertedDate ? convertedDate.date_string.replace("/", " ") : "",
       // created: data.created ? data.created.toDate().toLocaleString() : '',
       // created_by: data.created_by || '',
       // updated: data.updated ? data.updated.toDate().toLocaleString() : '',


### PR DESCRIPTION
- Change from date value get from DatePicker to something like this: "YYYYMM". Store to Firebase as number for sorting
- When show on client it should be showing Jan 2024 in each deck card but in admin deck when users open a edit form it should show date value of that Catalogue Edition new format value.
- Remove all momentjs handlers because we don't need it anymore.
- Remove static date format in stores
- Make changes in SearchPage.vue, Decks.vue for deck card